### PR TITLE
Ability to select and copy comment text

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -170,6 +170,10 @@
       </intent-filter>
     </activity>
 
+    <activity
+      android:name=".ui.submission.comment.TextSelectionDialogActivity"
+      android:theme="@style/DankTheme.DialogLikeActivity" />
+
     <service
       android:name=".ui.subscriptions.SubredditSubscriptionsSyncJob"
       android:exported="true"

--- a/app/src/main/java/me/saket/dank/ui/submission/CommentOptionsPopup.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/CommentOptionsPopup.java
@@ -14,6 +14,7 @@ import dagger.Lazy;
 import me.saket.dank.R;
 import me.saket.dank.di.Dank;
 import me.saket.dank.reddit.Reddit;
+import me.saket.dank.ui.submission.comment.TextSelectionDialogActivity;
 import me.saket.dank.utils.Clipboards;
 import me.saket.dank.utils.Intents;
 import me.saket.dank.utils.NestedOptionsPopupMenu;
@@ -27,6 +28,7 @@ public class CommentOptionsPopup extends NestedOptionsPopupMenu {
   private static final int ID_UNSAVE = 1_2;
   private static final int ID_SHARE_PERMALINK = 2;
   private static final int ID_COPY_PERMALINK = 3;
+  private static final int ID_SELECT_TEXT = 4;
 
   @Inject Lazy<Markdown> markdown;
   @Inject Lazy<BookmarksRepository> bookmarksRepository;
@@ -42,7 +44,6 @@ public class CommentOptionsPopup extends NestedOptionsPopupMenu {
   }
 
   private MenuStructure menuStructure(Context c) {
-    //noinspection AccessStaticViaInstance
     String commentBody = markdown.get().stripMarkdown(comment);
 
     List<MenuStructure.SingleLineItem> primaryItems = new ArrayList<>(3);
@@ -73,6 +74,11 @@ public class CommentOptionsPopup extends NestedOptionsPopupMenu {
         ID_COPY_PERMALINK,
         c.getString(R.string.submission_comment_option_copy_link),
         R.drawable.ic_copy_20dp
+    ));
+    primaryItems.add(MenuStructure.SingleLineItem.create(
+        ID_SELECT_TEXT,
+        c.getString(R.string.submission_comment_option_select_text),
+        R.drawable.ic_select_all_20dp
     ));
     return MenuStructure.create(commentBody, primaryItems);
   }
@@ -106,6 +112,11 @@ public class CommentOptionsPopup extends NestedOptionsPopupMenu {
       case ID_COPY_PERMALINK:
         Clipboards.save(c, permalinkWithContext);
         Toast.makeText(c, R.string.copy_to_clipboard_confirmation, Toast.LENGTH_SHORT).show();
+        break;
+
+      case ID_SELECT_TEXT:
+        CharSequence text = markdown.get().parse(comment);
+        c.startActivity(TextSelectionDialogActivity.intent(c, text));
         break;
 
       default:

--- a/app/src/main/java/me/saket/dank/ui/submission/SubmissionPageLayout.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/SubmissionPageLayout.java
@@ -101,6 +101,7 @@ import me.saket.dank.ui.submission.adapter.SubmissionRemoteComment;
 import me.saket.dank.ui.submission.adapter.SubmissionScreenUiModel;
 import me.saket.dank.ui.submission.adapter.SubmissionUiConstructor;
 import me.saket.dank.ui.submission.events.CommentClicked;
+import me.saket.dank.ui.submission.events.CommentLongClicked;
 import me.saket.dank.ui.submission.events.CommentOptionSwipeEvent;
 import me.saket.dank.ui.submission.events.ContributionVoteSwipeEvent;
 import me.saket.dank.ui.submission.events.InlineReplyRequestEvent;
@@ -815,6 +816,12 @@ public class SubmissionPageLayout extends ExpandablePageLayout implements Expand
           }
           commentTreeUiConstructor.toggleCollapse(clickEvent.comment());
         });
+
+    // Show text selection dialog on comment long-clicks.
+    commentsAdapter.uiEvents()
+        .ofType(CommentLongClicked.class)
+        .takeUntil(lifecycle().onDestroy())
+        .subscribe(longClickEvent -> longClickEvent.openTextSelectionDialog(getContext()));
 
     // Thread continuations.
     commentsAdapter.streamLoadMoreCommentsClicks()

--- a/app/src/main/java/me/saket/dank/ui/submission/adapter/SubmissionRemoteComment.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/adapter/SubmissionRemoteComment.java
@@ -30,6 +30,7 @@ import me.saket.dank.data.SwipeEvent;
 import me.saket.dank.ui.UiEvent;
 import me.saket.dank.ui.submission.CommentSwipeActionsProvider;
 import me.saket.dank.ui.submission.events.CommentClicked;
+import me.saket.dank.ui.submission.events.CommentLongClicked;
 import me.saket.dank.utils.DankLinkMovementMethod;
 import me.saket.dank.widgets.IndentedLayout;
 import me.saket.dank.widgets.swipe.SwipeableLayout;
@@ -145,10 +146,14 @@ public interface SubmissionRemoteComment {
       );
     }
 
-    public void setupCollapseOnClick(Relay<UiEvent> uiEvents) {
+    public void setupClickEvents(Relay<UiEvent> uiEvents) {
       itemView.setOnClickListener(o -> {
         boolean willCollapse = !uiModel.isCollapsed();
         uiEvents.accept(CommentClicked.create(uiModel.comment(), getAdapterPosition(), itemView, willCollapse));
+      });
+      itemView.setOnLongClickListener(v -> {
+        uiEvents.accept(new CommentLongClicked(uiModel.body()));
+        return true;
       });
     }
 
@@ -215,7 +220,7 @@ public interface SubmissionRemoteComment {
       ViewHolder holder = ViewHolder.create(inflater, parent);
       holder.setBodyLinkMovementMethod(linkMovementMethod);
       holder.setupGestures(swipeActionsProvider);
-      holder.setupCollapseOnClick(uiEvents);
+      holder.setupClickEvents(uiEvents);
       holder.forwardTouchEventsToBackground(linkMovementMethod);
       return holder;
     }

--- a/app/src/main/java/me/saket/dank/ui/submission/comment/TextSelectionDialogActivity.kt
+++ b/app/src/main/java/me/saket/dank/ui/submission/comment/TextSelectionDialogActivity.kt
@@ -1,0 +1,50 @@
+package me.saket.dank.ui.submission.comment
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.TextView
+import butterknife.BindView
+import butterknife.ButterKnife
+import me.saket.dank.R
+import me.saket.dank.ui.DankActivity
+
+class TextSelectionDialogActivity : DankActivity() {
+
+  @BindView(R.id.textselectiondialog_text)
+  lateinit var selectableTextView: TextView
+
+  @BindView(R.id.textselectiondialog_root)
+  lateinit var rootGroup: ViewGroup
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentView(R.layout.activity_dialog_text_selection)
+    ButterKnife.bind(this)
+
+    window.setBackgroundDrawableResource(R.color.dialog_like_activity_window_background)
+
+    overridePendingTransition(R.anim.dialog_fade_in, 0)
+
+    selectableTextView.text = intent.getCharSequenceExtra(EXTRA_TEXT)
+    rootGroup.setOnClickListener {
+      finish()
+    }
+  }
+
+  override fun finish() {
+    super.finish()
+    overridePendingTransition(0, R.anim.dialog_fade_out)
+  }
+
+  companion object {
+    private const val EXTRA_TEXT = "TextSelectionDialogActivity.text"
+
+    @JvmStatic
+    fun intent(context: Context, text: CharSequence) =
+      Intent(context, TextSelectionDialogActivity::class.java).apply {
+        putExtra(EXTRA_TEXT, text)
+      }
+  }
+}

--- a/app/src/main/java/me/saket/dank/ui/submission/events/CommentLongClicked.kt
+++ b/app/src/main/java/me/saket/dank/ui/submission/events/CommentLongClicked.kt
@@ -1,0 +1,13 @@
+package me.saket.dank.ui.submission.events
+
+import android.content.Context
+import me.saket.dank.ui.UiEvent
+import me.saket.dank.ui.submission.comment.TextSelectionDialogActivity
+
+data class CommentLongClicked(private val text: CharSequence) : UiEvent {
+
+  fun openTextSelectionDialog(context: Context) {
+    val intent = TextSelectionDialogActivity.intent(context, text)
+    context.startActivity(intent)
+  }
+}

--- a/app/src/main/res/drawable/ic_select_all_20dp.xml
+++ b/app/src/main/res/drawable/ic_select_all_20dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="20dp"
+  android:height="20dp"
+  android:viewportWidth="24.0"
+  android:viewportHeight="24.0">
+  <path
+    android:fillColor="#FFF"
+    android:pathData="M3,5h2L5,3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z" />
+</vector>

--- a/app/src/main/res/layout/activity_dialog_text_selection.xml
+++ b/app/src/main/res/layout/activity_dialog_text_selection.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:id="@+id/textselectiondialog_root"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <ScrollView
+    android:id="@+id/textselectiondialog_container"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:layout_marginStart="@dimen/spacing24"
+    android:layout_marginTop="@dimen/spacing48"
+    android:layout_marginEnd="@dimen/spacing24"
+    android:layout_marginBottom="@dimen/spacing48"
+    android:background="@drawable/background_popup_window"
+    android:clipToPadding="false"
+    android:elevation="@dimen/elevation_fab"
+    android:padding="@dimen/spacing12"
+    android:scrollbarStyle="outsideOverlay"
+    tools:ignore="UselessParent">
+
+    <me.saket.dank.utils.markdown.markwon.MarkdownTextView
+      android:id="@+id/textselectiondialog_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:inputType="none"
+      android:selectAllOnFocus="true"
+      android:textColor="@color/submission_comment_body_expanded"
+      android:textIsSelectable="true"
+      android:textSize="@dimen/submission_comment_body_expanded"
+      tools:text="That boss was my favourite. I bought Dark Souls after hearing how crushingly difficult it was from a friend of mine. He kept warning me about that boss and told me to prepare for a really difficult time." />
+
+  </ScrollView>
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,7 @@
   <string name="submission_comment_option_unsave">Unsave</string>
   <string name="submission_comment_option_share_link">Share link</string>
   <string name="submission_comment_option_copy_link">Copy link</string>
+  <string name="submission_comment_option_select_text">Select text</string>
 
   <string name="link_option_share">Share link</string>
   <string name="link_option_copy">Copy link</string>


### PR DESCRIPTION
# Summary

This pull request adds a special dialog with text selection behavior for comments. It is either accessible from options menu or by long pressing on a comment. When opened the user can select whole text or a part of it by use of standard text selection gestures.

# Examples

Available as an action in options dialog:
![eO6Ua32OyK](https://user-images.githubusercontent.com/5156340/67144929-cf579200-f27c-11e9-8af1-12e921f12821.gif)

Accessible via long-click gesture:
![N7yYsuo2Np](https://user-images.githubusercontent.com/5156340/67144911-9b7c6c80-f27c-11e9-98f9-809955481fb1.gif)

# Markdown

I also wanted to keep the formatted comment markdown in the popup but for some reason it doesn't apply the styles from spans. I'm not sure what is missing here for it to work. Perhaps someone else has any ideas?

___

Closes #81 