### PR TITLE
Fix image loading issues due to http urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Occasional crash when entering login screen ([#103](https://github.com/Tunous/Dawn/pull/103))
 - Crash when navigating to user profile ([#109](https://github.com/Tunous/Dawn/pull/109))
+- Image loading issues due to http urls ([#183](https://github.com/Tunous/Dawn/pull/183))
 
 ## [0.8.0] - 2019-08-22
 ### Added

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -213,7 +213,12 @@ public class UrlParser {
       return GenericMediaLink.create(httpsUrl, getMediaUrlType(urlPath));
 
     } else if (isImageOrGifUrlPath(urlPath) || isVideoPath(urlPath)) {
-      return GenericMediaLink.create(url, getMediaUrlType(urlPath));
+      if (Objects.equals(linkURI.getScheme(), "https")) {
+        return GenericMediaLink.create(url, getMediaUrlType(urlPath));
+      } else {
+        // show non-https media in WebView
+        return ExternalLink.create(url);
+      }
 
     } else {
       return ExternalLink.create(url);

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -9,6 +9,7 @@ import com.nytimes.android.external.cache3.Cache;
 
 import net.dean.jraw.models.Submission;
 
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 
@@ -158,10 +159,17 @@ public class UrlParser {
     return parsedLink;
   }
 
+  private String rewriteAsHttps(String link) {
+    Uri uri = Uri.parse(link);
+    if (Objects.equals(uri.getScheme(), "http")) {
+      return uri.buildUpon().scheme("https").build().toString();
+    }
+    return link;
+  }
+
   private Link parseNonRedditUrl(String url) {
     Uri linkURI = Uri.parse(url);
 
-    final String urlScheme = linkURI.getScheme() != null ? linkURI.getScheme() : "";
     final String urlDomain = linkURI.getHost() != null ? linkURI.getHost() : "";
     final String urlPath = linkURI.getPath() != null ? linkURI.getPath() : "";
 
@@ -196,13 +204,13 @@ public class UrlParser {
     } else if (urlDomain.contains("reddituploads.com") || urlDomain.contains("redditmedia.com")) {
       // Reddit sends HTML-escaped URLs for reddituploads.com. Decode them again.
       //noinspection deprecation
-      String htmlUnescapedUrl = org.jsoup.parser.Parser.unescapeEntities(url, true);
+      String htmlUnescapedUrl = rewriteAsHttps(org.jsoup.parser.Parser.unescapeEntities(url, true));
       return GenericMediaLink.create(htmlUnescapedUrl, Link.Type.SINGLE_IMAGE);
 
-    } else if (urlDomain.endsWith("redd.it") && urlScheme.equals("http")) {
+    } else if (urlDomain.endsWith("redd.it")) {
       // force https for *redd.it links to avoid problems with networkSecurityConfig
-      Uri httpsUrl = linkURI.buildUpon().scheme("https").build();
-      return GenericMediaLink.create(httpsUrl.toString(), getMediaUrlType(urlPath));
+      String httpsUrl = rewriteAsHttps(url);
+      return GenericMediaLink.create(httpsUrl, getMediaUrlType(urlPath));
 
     } else if (isImageOrGifUrlPath(urlPath) || isVideoPath(urlPath)) {
       return GenericMediaLink.create(url, getMediaUrlType(urlPath));

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -161,8 +161,9 @@ public class UrlParser {
   private Link parseNonRedditUrl(String url) {
     Uri linkURI = Uri.parse(url);
 
-    String urlDomain = linkURI.getHost() != null ? linkURI.getHost() : "";
-    String urlPath = linkURI.getPath() != null ? linkURI.getPath() : "";
+    final String urlScheme = linkURI.getScheme() != null ? linkURI.getScheme() : "";
+    final String urlDomain = linkURI.getHost() != null ? linkURI.getHost() : "";
+    final String urlPath = linkURI.getPath() != null ? linkURI.getPath() : "";
 
     if ((urlDomain.contains("imgur.com") || urlDomain.contains("bildgur.de"))) {
       if (isUnsupportedImgurLink(urlPath)) {
@@ -197,6 +198,11 @@ public class UrlParser {
       //noinspection deprecation
       String htmlUnescapedUrl = org.jsoup.parser.Parser.unescapeEntities(url, true);
       return GenericMediaLink.create(htmlUnescapedUrl, Link.Type.SINGLE_IMAGE);
+
+    } else if (urlDomain.endsWith("redd.it") && urlScheme.equals("http")) {
+      // force https for *redd.it links to avoid problems with networkSecurityConfig
+      Uri httpsUrl = linkURI.buildUpon().scheme("https").build();
+      return GenericMediaLink.create(httpsUrl.toString(), getMediaUrlType(urlPath));
 
     } else if (isImageOrGifUrlPath(urlPath) || isVideoPath(urlPath)) {
       return GenericMediaLink.create(url, getMediaUrlType(urlPath));


### PR DESCRIPTION
Recently I stumbled across this:
```
Media content load error: 
java.util.concurrent.ExecutionException: com.bumptech.glide.load.engine.GlideException: Failed to load resource
There was 1 cause:
java.net.UnknownServiceException(CLEARTEXT communication to i.redd.it not permitted by network security policy)
```
\- http redd.it link in the wild. This happens since Android >=9 forces https-only network security policy. Here's the fix