### PR TITLE
Add workflows related to release automation

### DIFF
--- a/.github/workflows/changelog_reminder.yml
+++ b/.github/workflows/changelog_reminder.yml
@@ -1,0 +1,14 @@
+name: Changelog Reminder
+on: pull_request
+jobs:
+  remind:
+    name: Changelog Reminder
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Changelog Reminder
+        uses: peterjgrainger/action-changelog-reminder@v1.2.0
+        with:
+          changelog_regex: 'CHANGELOG\.md'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,13 @@ jobs:
           name: Dawn Release Bundle
           path: artifacts
 
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v1.1.0
+        with:
+          version: ${{ github.ref }}
+          path: ./CHANGELOG.md
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -99,8 +106,13 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
+          body: ${{ steps.changelog_reader.outputs.log_entry }}
           draft: false
           prerelease: false
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
       - name: Upload Release Apk
         uses: actions/upload-release-asset@v1
@@ -109,7 +121,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./artifacts/app-release.apk
-          asset_name: Dawn_${{ github.ref }}.apk
+          asset_name: Dawn_${{ steps.get_version.outputs.VERSION }}.apk
           asset_content_type: application/vnd.android.package-archive
 
       - name: Upload Release Bundle
@@ -119,5 +131,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./artifacts/app-release.aab
-          asset_name: Dawn_${{ github.ref }}.aab
+          asset_name: Dawn_${{ steps.get_version.outputs.VERSION }}.aab
           asset_content_type: application/octet-stream

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -1,0 +1,45 @@
+name: "Draft new release"
+
+on:
+  milestone:
+    types: [closed]
+
+jobs:
+  draft-new-release:
+    name: "Draft a new release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract version from milestone
+        run: |
+          VERSION="${{ github.event.milestone.title }}"
+          echo "::set-env name=RELEASE_VERSION::$VERSION"
+
+      - name: Create release branch
+        run: git checkout -b release/${{ env.RELEASE_VERSION }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
+        with:
+          version: ${{ env.RELEASE_VERSION }}
+
+      - name: Initialize git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Commit changelog
+        run: |
+          git add CHANGELOG.md
+          git commit --message "Prepare release ${{ env.RELEASE_VERSION }}"
+
+      - name: Push new branch
+        run: git push origin release/${{ env.RELEASE_VERSION }}
+
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          head: release/${{ env.RELEASE_VERSION }}
+          base: master
+          title: Release ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
The idea of this pull request is to improve creation of new releases by making tasks related to changelogs automated. This in turn should (partially) prevent me from not uploading new changes to Play Store 😄 

1. `changelog_reminder.yml`
Posts an automatic comment whenever someone creates a pull request without changes in `CHANGELOG.md` file.

2. `release_draft.yml`
Automatically creates a pull request with preparation for new release whenever a milestone is closed. In the created pull requests it modifies the `CHANGELOG.md` file by making necessary changes for a new release.

3. `release.yml`
Fixed naming of assets and added step which automatically extracts correct entries from `CHANGELOG.md` file and inputs them into created GitHub release.

Unfortunately all of this is untested so I have no idea if it will work at all. Will either have to merge this as is and hope for the best or find a way to test these changes...

