### PR TITLE
Fix Imgur images loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 ### Fixed
+- Imgur images (up)loading ([#202](https://github.com/Tunous/Dawn/pull/202))
 
 ## [0.9.1] - 2020-05-05
 ### Fixed

--- a/app/src/main/java/me/saket/dank/data/ErrorResolver.kt
+++ b/app/src/main/java/me/saket/dank/data/ErrorResolver.kt
@@ -4,8 +4,6 @@ import com.bumptech.glide.load.engine.GlideException
 import io.reactivex.exceptions.CompositeException
 import io.reactivex.exceptions.UndeliverableException
 import me.saket.dank.R
-import me.saket.dank.data.exceptions.ImgurApiRequestRateLimitReachedException
-import me.saket.dank.data.exceptions.ImgurApiUploadRateLimitReachedException
 import okhttp3.internal.http2.ConnectionShutdownException
 import okhttp3.internal.http2.StreamResetException
 import retrofit2.HttpException
@@ -56,18 +54,6 @@ constructor() {
           ResolvedError.Type.REDDIT_IS_DOWN,
           R.string.common_reddit_is_down_error_emoji,
           R.string.common_reddit_is_down_error_message)
-
-    } else if (actualError is ImgurApiRequestRateLimitReachedException) {
-      ResolvedError.create(
-          ResolvedError.Type.IMGUR_RATE_LIMIT_REACHED,
-          R.string.common_imgur_rate_limit_error_emoji,
-          R.string.common_imgur_request_rate_limit_error_message)
-
-    } else if (actualError is ImgurApiUploadRateLimitReachedException) {
-      ResolvedError.create(
-          ResolvedError.Type.IMGUR_RATE_LIMIT_REACHED,
-          R.string.common_imgur_rate_limit_error_emoji,
-          R.string.common_imgur_upload_rate_limit_error_message)
 
     } else if (actualError is CancellationException || actualError is InterruptedIOException || actualError is InterruptedException) {
       ResolvedError.create(

--- a/app/src/main/java/me/saket/dank/data/ResolvedError.java
+++ b/app/src/main/java/me/saket/dank/data/ResolvedError.java
@@ -47,10 +47,6 @@ public abstract class ResolvedError {
     return type() == Type.REDDIT_IS_DOWN;
   }
 
-  public boolean isImgurRateLimitError() {
-    return type() == Type.IMGUR_RATE_LIMIT_REACHED;
-  }
-
   public static ResolvedError create(Type type, @StringRes int errorEmoji, @StringRes int errorMessage) {
     return new AutoValue_ResolvedError(type, errorEmoji, errorMessage);
   }

--- a/app/src/main/java/me/saket/dank/data/exceptions/ImgurApiRequestRateLimitReachedException.java
+++ b/app/src/main/java/me/saket/dank/data/exceptions/ImgurApiRequestRateLimitReachedException.java
@@ -1,7 +1,0 @@
-package me.saket.dank.data.exceptions;
-
-/**
- * Thrown when Dank runs out Imgur rate limits, in order to avoid over-billing.
- */
-public class ImgurApiRequestRateLimitReachedException extends RuntimeException {
-}

--- a/app/src/main/java/me/saket/dank/data/exceptions/ImgurApiUploadRateLimitReachedException.java
+++ b/app/src/main/java/me/saket/dank/data/exceptions/ImgurApiUploadRateLimitReachedException.java
@@ -1,7 +1,0 @@
-package me.saket.dank.data.exceptions;
-
-/**
- * Thrown when Dank runs out Imgur rate limits, in order to avoid over-billing.
- */
-public class ImgurApiUploadRateLimitReachedException extends RuntimeException {
-}

--- a/app/src/main/java/me/saket/dank/di/DankApi.java
+++ b/app/src/main/java/me/saket/dank/di/DankApi.java
@@ -31,10 +31,6 @@ public interface DankApi {
 
 // ======== IMGUR ======== //
 
-  /**
-   * Get images in an Imgur album. This is a paid API so we try to minimize its usage. The response
-   * is wrapped in {@link Response} so that the headers can be extracted for checking Imgur rate-limits.
-   */
   @CheckResult
   @GET("https://api.imgur.com/3/album/{albumId}")
   @Headers({ HEADER_IMGUR_AUTH })

--- a/app/src/main/java/me/saket/dank/di/DankApi.java
+++ b/app/src/main/java/me/saket/dank/di/DankApi.java
@@ -25,7 +25,6 @@ import retrofit2.http.Query;
 public interface DankApi {
 
   String HEADER_IMGUR_AUTH = "Authorization: Client-ID 87450e5590435e9";
-  String HEADER_MASHAPE_KEY = "X-Mashape-Key: VOjpM0pXeAmshuRGE4Hhe6KY9Ouep1YCLx8jsnaivCFNYALpN5";
   String HEADER_WHOLESOME_API_AUTH = "Authorization";
   String WHOLESOME_API_HOST = "dank-wholesome.herokuapp.com";
   String GIPHY_API_KEY = "SFGHZ6SYGn3AzZ07b2tNpENCEDdYTzpB";
@@ -37,8 +36,8 @@ public interface DankApi {
    * is wrapped in {@link Response} so that the headers can be extracted for checking Imgur rate-limits.
    */
   @CheckResult
-  @GET("https://imgur-apiv3.p.mashape.com/3/album/{albumId}")
-  @Headers({ HEADER_IMGUR_AUTH, HEADER_MASHAPE_KEY })
+  @GET("https://api.imgur.com/3/album/{albumId}")
+  @Headers({ HEADER_IMGUR_AUTH })
   Single<Response<ImgurAlbumResponse>> imgurAlbum(
       @Path("albumId") String albumId
   );
@@ -47,16 +46,16 @@ public interface DankApi {
    * Get an image's details from Imgur. This is also a paid API.
    */
   @CheckResult
-  @GET("https://imgur-apiv3.p.mashape.com/3/image/{imageId}")
-  @Headers({ HEADER_IMGUR_AUTH, HEADER_MASHAPE_KEY })
+  @GET("https://api.imgur.com/3/image/{imageId}")
+  @Headers({ HEADER_IMGUR_AUTH })
   Single<Response<ImgurImageResponse>> imgurImage(
       @Path("imageId") String imageId
   );
 
   @CheckResult
   @Multipart
-  @POST("https://imgur-apiv3.p.mashape.com/3/image")
-  @Headers({ HEADER_IMGUR_AUTH, HEADER_MASHAPE_KEY })
+  @POST("https://api.imgur.com/3/image")
+  @Headers({ HEADER_IMGUR_AUTH })
   Single<Response<ImgurUploadResponse>> uploadToImgur(
       @Part MultipartBody.Part file,
       @Query("type") String fileType

--- a/app/src/main/java/me/saket/dank/ui/compose/UploadImageDialog.java
+++ b/app/src/main/java/me/saket/dank/ui/compose/UploadImageDialog.java
@@ -236,13 +236,11 @@ public class UploadImageDialog extends DankDialogFragment {
         String emoji = getResources().getString(resolvedError.errorEmojiRes());
         String errorMessage = getResources().getString(resolvedError.errorMessageRes());
 
-        if (!resolvedError.isImgurRateLimitError()) {
-          String tapToRetryText = getResources().getString(R.string.composereply_uploadimage_tap_to_retry);
-          if (!errorMessage.endsWith(getResources().getString(R.string.composereply_uploadimage_error_message_period))) {
-            errorMessage += getResources().getString(R.string.composereply_uploadimage_error_message_period);
-          }
-          errorMessage += " " + tapToRetryText;
+        String tapToRetryText = getResources().getString(R.string.composereply_uploadimage_tap_to_retry);
+        if (!errorMessage.endsWith(getResources().getString(R.string.composereply_uploadimage_error_message_period))) {
+          errorMessage += getResources().getString(R.string.composereply_uploadimage_error_message_period);
         }
+        errorMessage += " " + tapToRetryText;
 
         errorView.setText(String.format("%s\n\n%s", emoji, errorMessage));
       }

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurRepository.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurRepository.java
@@ -162,12 +162,14 @@ public class ImgurRepository {
   private Consumer<Response> saveImgurApiRateLimits() {
     return response -> {
       Headers responseHeaders = response.headers();
-      saveApiRequestLimit(parseInt(responseHeaders.get("X-RateLimit-Requests-Limit")));
-      saveRemainingApiRequests(parseInt(responseHeaders.get("X-RateLimit-Requests-Remaining")));
-      saveApiUploadLimit(parseInt(responseHeaders.get("X-RateLimit-Uploads-Limit")));
-      saveRemainingApiUploads(parseInt(responseHeaders.get("X-RateLimit-Uploads-Remaining")));
+      try {
+        saveApiRequestLimit(parseInt(responseHeaders.get("X-RateLimit-Requests-Limit")));
+        saveRemainingApiRequests(parseInt(responseHeaders.get("X-RateLimit-Requests-Remaining")));
+        saveApiUploadLimit(parseInt(responseHeaders.get("X-RateLimit-Uploads-Limit")));
+        saveRemainingApiUploads(parseInt(responseHeaders.get("X-RateLimit-Uploads-Remaining")));
 
-      saveRateLimitsLastCheckedAt(responseHeaders.getDate("Date").getTime());
+        saveRateLimitsLastCheckedAt(responseHeaders.getDate("Date").getTime());
+      } catch (NumberFormatException ignored) {} // Do not save rate limits if they're not present
     };
   }
 

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurRepository.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurRepository.java
@@ -1,8 +1,6 @@
 package me.saket.dank.ui.media;
 
 import android.app.Application;
-import android.content.Context;
-import android.content.SharedPreferences;
 
 import androidx.annotation.CheckResult;
 
@@ -10,33 +8,24 @@ import com.jakewharton.rxrelay2.BehaviorRelay;
 import com.jakewharton.rxrelay2.Relay;
 
 import java.io.File;
-import java.util.TimeZone;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import hirondelle.date4j.DateTime;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import io.reactivex.functions.Consumer;
 import io.reactivex.functions.Function;
 import me.saket.dank.data.FileUploadProgressEvent;
-import me.saket.dank.data.exceptions.ImgurApiRequestRateLimitReachedException;
-import me.saket.dank.data.exceptions.ImgurApiUploadRateLimitReachedException;
 import me.saket.dank.data.exceptions.InvalidImgurAlbumException;
 import me.saket.dank.di.DankApi;
 import me.saket.dank.urlparser.ImgurAlbumUnresolvedLink;
 import me.saket.dank.utils.okhttp.OkHttpRequestBodyWithProgress;
 import me.saket.dank.utils.okhttp.OkHttpRequestWriteProgressListener;
-import okhttp3.Headers;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.RequestBody;
 import retrofit2.HttpException;
 import retrofit2.Response;
-import timber.log.Timber;
-
-import static java.lang.Integer.parseInt;
 
 /**
  * TODO: Tests.
@@ -44,40 +33,21 @@ import static java.lang.Integer.parseInt;
 @Singleton
 public class ImgurRepository {
 
-  private static final String KEY_REQUEST_LIMIT = "requestsLimit";
-  private static final String KEY_REMAINING_REQUESTS = "remainingRequests";
-  private static final String KEY_UPLOAD_LIMIT = "uploadsLimit";
-  private static final String KEY_REMAINING_UPLOADS = "remainingUploads";
-  private static final String KEY_RATE_LIMIT_LAST_CHECK = "rateLimitsLastCheck";
-
-  /**
-   * Stop all Imgur requests once we're only left with 10% of our allocated requests.
-   */
-  private static final float LIMIT_THRESHOLD_FACTOR = 0.1f;
-
-  private final SharedPreferences sharedPreferences;
   private final DankApi dankApi;
 
   @Inject
-  public ImgurRepository(Application appContext, DankApi dankApi) {
-    sharedPreferences = appContext.getSharedPreferences(appContext.getPackageName() + "_imgur_ratelimits", Context.MODE_PRIVATE);
+  public ImgurRepository(Application _appContext, DankApi dankApi) {
     this.dankApi = dankApi;
   }
 
   /**
-   * <p>
-   * TODO: If needed, get the rate limits if they're not cached.
-   * Remember to handle {@link ImgurApiRequestRateLimitReachedException}.
-   *
    * @throws InvalidImgurAlbumException               If an invalid Imgur link was found. Right now this happens only when no images are
    *                                                  returned by Imgur.
-   * @throws ImgurApiRequestRateLimitReachedException If Imgur's API limit is reached and no more API requests can be made till the next month.
    */
   public Single<ImgurResponse> gallery(ImgurAlbumUnresolvedLink imgurAlbumUnresolvedLink) {
     return dankApi.imgurAlbum(imgurAlbumUnresolvedLink.albumId())
         .map(throwIfHttpError())
-        .doOnSuccess(saveImgurApiRateLimits())
-        .map(response -> response.body())
+        .map(Response::body)
         .onErrorResumeNext(error -> {
           // Api returns a 404 when it was a single image and not an album.
           if (error instanceof HttpException && ((HttpException) error).code() == 404) {
@@ -93,29 +63,16 @@ public class ImgurRepository {
           } else {
             // Okay, let's check if it was a single image.
             return dankApi.imgurImage(imgurAlbumUnresolvedLink.albumId())
-                .doOnSuccess(saveImgurApiRateLimits())
-                .map(response -> response.body());
+                .map(Response::body);
           }
         })
         .doOnSuccess(albumResponse -> {
           if (!albumResponse.hasImages()) {
             throw new InvalidImgurAlbumException();
           }
-        })
-        .doOnSubscribe(o -> {
-          resetRateLimitsIfMonthChanged();
-
-          if (isApiRequestLimitReached()) {
-            throw new ImgurApiRequestRateLimitReachedException();
-          } else {
-            Timber.i("Rate limits not reached");
-          }
         });
   }
 
-  /**
-   * Remember to handle {@link ImgurApiUploadRateLimitReachedException}.
-   */
   @CheckResult
   public Observable<FileUploadProgressEvent<ImgurUploadResponse>> uploadImage(File imageFile, String mimeType) {
     Relay<Float> uploadProgressStream = BehaviorRelay.createDefault(0f);
@@ -130,22 +87,12 @@ public class ImgurRepository {
 
     Observable<FileUploadProgressEvent<ImgurUploadResponse>> uploadStream = dankApi.uploadToImgur(multipartBodyPart, "file")
         .map(throwIfHttpError())
-        .doOnSuccess(saveImgurApiRateLimits())
-        .map(response -> response.body())
-        .doOnSubscribe(o -> {
-          resetRateLimitsIfMonthChanged();
-
-          if (isApiUploadLimitReached()) {
-            throw new ImgurApiUploadRateLimitReachedException();
-          } else {
-            Timber.i("Rate limits not reached");
-          }
-        })
-        .map(response -> FileUploadProgressEvent.createUploaded(response))
+        .map(Response::body)
+        .map(FileUploadProgressEvent::createUploaded)
         .toObservable();
 
     return uploadProgressStream
-        .map(progress -> FileUploadProgressEvent.<ImgurUploadResponse>createInFlight(progress))
+        .map(FileUploadProgressEvent::<ImgurUploadResponse>createInFlight)
         .mergeWith(uploadStream);
   }
 
@@ -159,90 +106,4 @@ public class ImgurRepository {
     };
   }
 
-  private Consumer<Response> saveImgurApiRateLimits() {
-    return response -> {
-      Headers responseHeaders = response.headers();
-      try {
-        saveApiRequestLimit(parseInt(responseHeaders.get("X-RateLimit-Requests-Limit")));
-        saveRemainingApiRequests(parseInt(responseHeaders.get("X-RateLimit-Requests-Remaining")));
-        saveApiUploadLimit(parseInt(responseHeaders.get("X-RateLimit-Uploads-Limit")));
-        saveRemainingApiUploads(parseInt(responseHeaders.get("X-RateLimit-Uploads-Remaining")));
-
-        saveRateLimitsLastCheckedAt(responseHeaders.getDate("Date").getTime());
-      } catch (NumberFormatException ignored) {} // Do not save rate limits if they're not present
-    };
-  }
-
-  private void saveRateLimitsLastCheckedAt(long lastCheckedMillis) {
-    sharedPreferences.edit().putLong(KEY_RATE_LIMIT_LAST_CHECK, lastCheckedMillis).apply();
-  }
-
-  private long rateLimitsLastCheckedAtMillis(long valueIfEmpty) {
-    return sharedPreferences.getLong(KEY_RATE_LIMIT_LAST_CHECK, valueIfEmpty);
-  }
-
-  private void resetRateLimitsIfMonthChanged() {
-    long lastCheckedMillis = rateLimitsLastCheckedAtMillis(-1);
-    if (lastCheckedMillis == -1) {
-      return;
-    }
-
-    DateTime lastCheckedDateTime = DateTime.forInstant(lastCheckedMillis, TimeZone.getTimeZone("UTC"));
-    DateTime nowDateTime = DateTime.now(TimeZone.getTimeZone("UTC"));
-
-    Timber.i("Now month: %s, Last checked month: %s", nowDateTime.getMonth(), lastCheckedDateTime.getMonth());
-
-    if (nowDateTime.getMonth() > lastCheckedDateTime.getMonth()) {
-      Timber.i("Months have changed. Resetting Imgur rate limit");
-
-      // Months have changed! Reset the limits.
-      sharedPreferences.edit().clear().apply();
-    }
-  }
-
-  private void saveRemainingApiRequests(int requestsRemaining) {
-    sharedPreferences.edit().putInt(KEY_REMAINING_REQUESTS, requestsRemaining).apply();
-  }
-
-  private void saveApiRequestLimit(int requestLimit) {
-    sharedPreferences.edit().putInt(KEY_REQUEST_LIMIT, requestLimit).apply();
-  }
-
-  private boolean isApiRequestLimitReached() {
-    if (sharedPreferences.contains(KEY_REMAINING_REQUESTS) && sharedPreferences.contains(KEY_REQUEST_LIMIT)) {
-      int remainingRequests = sharedPreferences.getInt(KEY_REMAINING_REQUESTS, 0);
-      int requestLimit = sharedPreferences.getInt(KEY_REQUEST_LIMIT, 0);
-
-      Timber.i("remainingRequests: %s", remainingRequests);
-      Timber.i("requestLimit: %s", requestLimit);
-
-      if (remainingRequests < requestLimit * LIMIT_THRESHOLD_FACTOR) {
-        Timber.w("Imgur api request limit reached :(");
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private void saveRemainingApiUploads(int uploadsRemaining) {
-    sharedPreferences.edit().putInt(KEY_REMAINING_UPLOADS, uploadsRemaining).apply();
-  }
-
-  private void saveApiUploadLimit(int uploadLimit) {
-    sharedPreferences.edit().putInt(KEY_UPLOAD_LIMIT, uploadLimit).apply();
-  }
-
-  private boolean isApiUploadLimitReached() {
-    if (sharedPreferences.contains(KEY_REMAINING_UPLOADS) && sharedPreferences.contains(KEY_UPLOAD_LIMIT)) {
-      int remainingUploads = sharedPreferences.getInt(KEY_REMAINING_UPLOADS, 0);
-      int uploadLimit = sharedPreferences.getInt(KEY_UPLOAD_LIMIT, 0);
-
-      if (remainingUploads < uploadLimit * LIMIT_THRESHOLD_FACTOR) {
-        Timber.i("remainingUploads: %s", remainingUploads);
-        Timber.i("uploadLimit: %s", uploadLimit);
-        return true;
-      }
-    }
-    return false;
-  }
 }

--- a/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
+++ b/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
@@ -298,7 +298,6 @@ public class MediaAlbumViewerActivity extends DankActivity implements MediaFragm
 
   private void resolveMediaLinkAndDisplayContent(MediaLink mediaLinkToDisplay) {
     mediaHostRepository.resolveActualLinkIfNeeded(mediaLinkToDisplay)
-        // TODO: Handle Imgur rate limit reached.
         .doOnNext(resolvedMediaLink -> this.resolvedMediaLink = resolvedMediaLink)
         .map(resolvedMediaLink -> {
           // Find all child images under an album.

--- a/app/src/main/java/me/saket/dank/ui/media/MediaHostRepository.java
+++ b/app/src/main/java/me/saket/dank/ui/media/MediaHostRepository.java
@@ -27,8 +27,6 @@ import me.saket.dank.cache.DiskLruCachePathResolver;
 import me.saket.dank.cache.StoreFilePersister;
 import me.saket.dank.data.CachedResolvedLinkInfo;
 import me.saket.dank.data.FileUploadProgressEvent;
-import me.saket.dank.data.exceptions.ImgurApiRequestRateLimitReachedException;
-import me.saket.dank.data.exceptions.ImgurApiUploadRateLimitReachedException;
 import me.saket.dank.ui.giphy.GiphyGif;
 import me.saket.dank.ui.giphy.GiphyRepository;
 import me.saket.dank.ui.media.gfycat.GfycatRepository;
@@ -154,9 +152,6 @@ public class MediaHostRepository {
         .subscribe();
   }
 
-  /**
-   * Remember to handle {@link ImgurApiRequestRateLimitReachedException}.
-   */
   public Observable<MediaLink> resolveActualLinkIfNeeded(MediaLink unresolvedLink) {
     return incorrectMediaUrlParsingData.get()
         .isFlagged(unresolvedLink)
@@ -215,9 +210,6 @@ public class MediaHostRepository {
     return imgurImageLinks;
   }
 
-  /**
-   * Remember to handle {@link ImgurApiUploadRateLimitReachedException}.
-   */
   @CheckResult
   public Observable<FileUploadProgressEvent<ImgurUploadResponse>> uploadImage(File image, String mimeType) {
     return imgurRepository.uploadImage(image, mimeType);

--- a/app/src/main/java/me/saket/dank/ui/submission/SubmissionPageLayout.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/SubmissionPageLayout.java
@@ -75,7 +75,6 @@ import me.saket.dank.data.OnLoginRequireListener;
 import me.saket.dank.data.ResolvedError;
 import me.saket.dank.data.StatusBarTint;
 import me.saket.dank.data.UserPreferences;
-import me.saket.dank.data.exceptions.ImgurApiRequestRateLimitReachedException;
 import me.saket.dank.di.Dank;
 import me.saket.dank.reply.Reply;
 import me.saket.dank.reply.ReplyRepository;
@@ -126,7 +125,6 @@ import me.saket.dank.ui.subreddit.SubredditActivity;
 import me.saket.dank.ui.subreddit.events.SubmissionOpenInNewTabSwipeEvent;
 import me.saket.dank.ui.subreddit.events.SubmissionOptionSwipeEvent;
 import me.saket.dank.ui.user.UserSessionRepository;
-import me.saket.dank.urlparser.ExternalLink;
 import me.saket.dank.urlparser.ImgurAlbumLink;
 import me.saket.dank.urlparser.Link;
 import me.saket.dank.urlparser.MediaLink;
@@ -1377,14 +1375,9 @@ public class SubmissionPageLayout extends ExpandablePageLayout implements Expand
               })
               .observeOn(mainThread())
               .onErrorResumeNext(error -> {
-                // Open this album in browser if Imgur rate limits have reached.
-                if (error instanceof ImgurApiRequestRateLimitReachedException) {
-                  return Observable.just(ExternalLink.create(parsedLink.unparsedUrl()));
-                } else {
-                  uiEvents.accept(SubmissionContentResolvingFailed.create());
-                  showMediaLoadError(error);
-                  return Observable.never();
-                }
+                uiEvents.accept(SubmissionContentResolvingFailed.create());
+                showMediaLoadError(error);
+                return Observable.never();
               });
         })
         .flatMapSingle(link -> {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,10 +32,6 @@
   <string name="common_reddit_is_down_error_emoji" translatable="false">(ಥ_ಥ)</string>
   <string name="common_reddit_is_down_error_message">You broke Reddit! It\'s under heavy load right now.</string>
 
-  <string name="common_imgur_rate_limit_error_emoji">ಥ_ಥ</string>
-  <string name="common_imgur_request_rate_limit_error_message">Dawn has reached its monthly limit of downloading images from Imgur.</string>
-  <string name="common_imgur_upload_rate_limit_error_message">Dawn has reached its monthly limit of uploading images to Imgur.</string>
-
   <string name="common_error_cancelation_emoji">( ͡° ͜ʖ ͡°)</string>
   <string name="common_error_cancelation_message">Something was intentionally canceled. The user should never see this.</string>
 


### PR DESCRIPTION
Seems like Imgur changed their paid api endpoint (very clever of them) and this caused imgur albums and images to stop loading.

Imgur api docs states this:

> The Imgur API is free for non-commercial usage. Your application is probably free if you don't plan on making any money with it, or if it's open source.

So i've just changed endpoint to the free one and it works so far (albums/images). I haven't checked uploading yet but according to docs this should work too. But comment in code says:

```
  /**
   * Get images in an Imgur album. This is a paid API so we try to minimize its usage. The response
   * is wrapped in {@link Response} so that the headers can be extracted for checking Imgur rate-limits.
   */
```

\- so I don't know if I just should update this to new paid endpoint. If we decide to keep free one, then all rate-limit code probably can be removed. 