### PR TITLE
Always show fullsize imgur images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix playing of reddit hosted videos ([#210](https://github.com/Tunous/Dawn/pull/210))
 - Imgur images (up)loading ([#202](https://github.com/Tunous/Dawn/pull/202))
+- Always show fullsize imgur images ([#209](https://github.com/Tunous/Dawn/pull/209))
 
 ## [0.9.1] - 2020-05-05
 ### Fixed

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -12,6 +12,7 @@ import net.dean.jraw.models.Submission;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -23,6 +24,7 @@ import me.saket.dank.utils.JrawUtils2;
 import me.saket.dank.utils.Optional;
 import me.saket.dank.utils.Urls;
 import okhttp3.HttpUrl;
+import timber.log.Timber;
 
 /**
  * Parses URLs found in the wilderness of Reddit and categorizes them into {@link Link} subclasses.
@@ -38,11 +40,13 @@ public class UrlParser {
 
   private final Cache<String, Link> cache;
   private final UrlParserConfig config;
+  private final Pattern imgurPreviewPat;
 
   @Inject
   public UrlParser(@Named("url_parser") Cache<String, Link> cache, UrlParserConfig config) {
     this.cache = cache;
     this.config = config;
+    this.imgurPreviewPat = Pattern.compile("_d\\.");
   }
 
   /**
@@ -261,13 +265,23 @@ public class UrlParser {
         .scheme("https")
         .build();
 
-    // Attempt to get direct links to images from Imgur submissions.
-    // For example, convert 'http://imgur.com/djP1IZC' to 'http://i.imgur.com/djP1IZC.jpg'.
-    if (!isImageOrGifUrlPath(url) && !url.endsWith("mp4")) {
-      // If this happened to be a GIF submission, the user sadly will be forced to see it instead of its GIFV.
-      imageUrl = imageUrl.newBuilder(imageUrl.encodedPath() + ".jpg")
-          .host("i.imgur.com")
-          .build();
+    String imageUrlPath = imageUrl.encodedPath();
+
+    if (!url.endsWith("mp4")) {
+      if (isImageOrGifUrlPath(imageUrlPath)) {
+        // Strip any preview-related suffixes and queries
+        imageUrl = imageUrl.newBuilder()
+            .encodedQuery(null)
+            .encodedPath(imgurPreviewPat.matcher(imageUrlPath).replaceFirst("."))
+            .build();
+      } else {
+        // Attempt to get direct links to images from Imgur submissions.
+        // For example, convert 'http://imgur.com/djP1IZC' to 'http://i.imgur.com/djP1IZC.jpg'.
+        // If this happened to be a GIF submission, the user sadly will be forced to see it instead of its GIFV.
+        imageUrl = imageUrl.newBuilder(imageUrlPath + ".jpg")
+            .host("i.imgur.com")
+            .build();
+      }
     }
 
     //noinspection ConstantConditions
@@ -360,7 +374,8 @@ public class UrlParser {
   }
 
   public static boolean isImagePath(String urlPath) {
-    return urlPath.endsWith(".png") || urlPath.endsWith(".jpg") || urlPath.endsWith(".jpeg");
+    return urlPath.endsWith(".png") || urlPath.endsWith(".jpg") ||
+        urlPath.endsWith(".jpeg") || urlPath.endsWith(".webp");
   }
 
   private static boolean isImageOrGifUrlPath(String urlPath) {

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -46,7 +46,7 @@ public class UrlParser {
   public UrlParser(@Named("url_parser") Cache<String, Link> cache, UrlParserConfig config) {
     this.cache = cache;
     this.config = config;
-    this.imgurPreviewPat = Pattern.compile("_d\\.");
+    this.imgurPreviewPat = Pattern.compile("_d(\\.\\w+)$");
   }
 
   /**
@@ -272,7 +272,7 @@ public class UrlParser {
         // Strip any preview-related suffixes and queries
         imageUrl = imageUrl.newBuilder()
             .encodedQuery(null)
-            .encodedPath(imgurPreviewPat.matcher(imageUrlPath).replaceFirst("."))
+            .encodedPath(imgurPreviewPat.matcher(imageUrlPath).replaceFirst("$1"))
             .build();
       } else {
         // Attempt to get direct links to images from Imgur submissions.

--- a/app/src/test/java/me/saket/dank/utils/UrlParserTest.java
+++ b/app/src/test/java/me/saket/dank/utils/UrlParserTest.java
@@ -44,7 +44,7 @@ import me.saket.dank.urlparser.UrlParser;
 import me.saket.dank.urlparser.UrlParserConfig;
 
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.*;
 import static org.mockito.AdditionalMatchers.or;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
@@ -373,7 +373,7 @@ public class UrlParserTest {
     for (String url : IMGUR_ALBUM_URLS) {
       try {
         Link parsedLink = urlParser.parse(url);
-        assertEquals(parsedLink instanceof ImgurAlbumUnresolvedLink, true);
+        assertTrue(parsedLink instanceof ImgurAlbumUnresolvedLink);
 
       } catch (Exception e) {
         throw new IllegalStateException("Exception for url: " + url, e);
@@ -381,7 +381,7 @@ public class UrlParserTest {
     }
 
     Link link = urlParser.parse("http://i.imgur.com/0Jp0l2R.jpg");
-    assertEquals(false, link instanceof ImgurAlbumUnresolvedLink);
+    assertFalse(link instanceof ImgurAlbumUnresolvedLink);
   }
 
   @Test
@@ -410,6 +410,20 @@ public class UrlParserTest {
     // Glide will eventually load a GIF though.
     Link parsedGifLinkWithoutExtension = urlParser.parse("https://imgur.com/a/qU24g");
     assertThat(parsedGifLinkWithoutExtension).isInstanceOf(ImgurAlbumUnresolvedLink.class);
+
+    // Preview urls should be transformed into fullsize urls
+    String[] previewUrls = {
+        "http://i.imgur.com/BU5XFMg_d.webp?maxwidth=640&shape=thumb&fidelity=medium",
+        "https://i.imgur.com/BU5XFMg.webp?maxwidth=640&shape=thumb&fidelity=medium",
+        "https://i.imgur.com/BU5XFMg_d.webp",
+        "https://i.imgur.com/BU5XFMg.webp",
+    };
+
+    for (String url : previewUrls) {
+      Link link = urlParser.parse(url);
+      assertTrue(link instanceof ImgurLink);
+      assertEquals(((ImgurLink) link).highQualityUrl(), "https://i.imgur.com/BU5XFMg.webp");
+    }
   }
 
   @Test


### PR DESCRIPTION
When submission contains direct imgur url sometimes Dawn were loading preview images. `_d` filename suffix and .webp extension both required to reproduce this. I've added webp as image format and also added stripping of `_d` just to be safe