### PR TITLE
Gfycat: fix id extraction & token refresh

### DIFF
--- a/app/src/main/java/me/saket/dank/di/DankApi.java
+++ b/app/src/main/java/me/saket/dank/di/DankApi.java
@@ -100,6 +100,7 @@ public interface DankApi {
 
   @CheckResult
   @GET("https://api.gfycat.com/v1/oauth/token?grant_type=client_credentials")
+  @Headers({"Accept: application/json,text/html"}) // fails with 400 if text/html is not present
   Single<GfycatOauthResponse> gfycatOAuth(
       @Query("client_id") String clientId,
       @Query("client_secret") String clientSecret

--- a/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatRepositoryData.java
+++ b/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatRepositoryData.java
@@ -23,8 +23,8 @@ public class GfycatRepositoryData {
 
   @Inject
   public GfycatRepositoryData(@Named("gfycat_repository") RxSharedPreferences kvStore) {
-    needsAccessTokenHeaderStore = kvStore.getBoolean("gfycat_needs_access_token", false);
-    accessTokenExpiryTimeMillisStore = kvStore.getLong("gfycat_access_token_expiry_time_millis", currentTimeMillis());
+    needsAccessTokenHeaderStore = kvStore.getBoolean("gfycat_needs_access_token2", false);
+    accessTokenExpiryTimeMillisStore = kvStore.getLong("gfycat_access_token_expiry_time_millis", 0L); // consider expired if absent
     accessTokenStore = kvStore.getString("gfycat_access_token", ACCESS_TOKEN_EMPTY_VALUE);
   }
 

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParserConfig.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParserConfig.java
@@ -44,7 +44,7 @@ public class UrlParserConfig {
    * /MessySpryAfricancivet.webm
    * /MessySpryAfricancivet-mobile.mp4
    */
-  private static final Pattern DEFAULT_GFYCAT_ID_PATTERN_2 = Pattern.compile("^/([^-.]*).*$");
+  private static final Pattern DEFAULT_GFYCAT_ID_PATTERN_2 = Pattern.compile("^.*/([^-.]*)[^/]*$");
 
   /**
    * Extracts the ID of a giphy link. In these examples, the ID is 'l2JJyLbhqCF4va86c


### PR DESCRIPTION
Fixes loading of gfycat media if link contains additional path segments (`/gifs/`, `/gifs/details/`, etc)