### PR TITLE
Don't show too small reddit previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Show smaller Imgur images when data saving mode enabled ([#256](https://github.com/Tunous/Dawn/pull/256))
+- Don't show too small reddit previews ([#264](https://github.com/Tunous/Dawn/pull/264))
 
 ## [0.9.2] - 2020-06-13
 

--- a/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
+++ b/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
@@ -250,6 +250,7 @@ public class MediaAlbumViewerActivity extends DankActivity implements MediaFragm
             ImageWithMultipleVariants imageVariants = ImageWithMultipleVariants.Companion.of(redditSuppliedImages);
             optimizedQualityUrl = imageVariants.findNearestFor(
                 getResources().getDisplayMetrics().widthPixels,
+                ImageWithMultipleVariants.DEFAULT_VIEWER_MIN_WIDTH,
                 activeMediaItem.mediaLink().lowQualityUrl() /* defaultValue */
             );
           }
@@ -648,7 +649,11 @@ public class MediaAlbumViewerActivity extends DankActivity implements MediaFragm
     Observable<File> optimizedResImageFileStream = getRedditSuppliedImages()
         .flatMapObservable(redditImages -> Observable.create(emitter -> {
           ImageWithMultipleVariants imageVariants = ImageWithMultipleVariants.Companion.of(redditImages);
-          String optimizedQualityImageForDevice = imageVariants.findNearestFor(getDeviceDisplayWidth(), albumItem.mediaLink().lowQualityUrl());
+          String optimizedQualityImageForDevice = imageVariants.findNearestFor(
+              getDeviceDisplayWidth(),
+              ImageWithMultipleVariants.DEFAULT_VIEWER_MIN_WIDTH,
+              albumItem.mediaLink().lowQualityUrl()
+          );
 
           FutureTarget<File> optimizedResolutionImageTarget = Glide.with(this)
               .download(optimizedQualityImageForDevice)

--- a/app/src/main/java/me/saket/dank/ui/media/MediaImageFragment.java
+++ b/app/src/main/java/me/saket/dank/ui/media/MediaImageFragment.java
@@ -178,7 +178,8 @@ public class MediaImageFragment extends BaseMediaViewerFragment {
                 } else {
                   int deviceDisplayWidth = ((MediaFragmentCallbacks) requireActivity()).getDeviceDisplayWidth();
                   ImageWithMultipleVariants imageWithMultipleVariants = ImageWithMultipleVariants.Companion.of(redditImages);
-                  imageUrl = imageWithMultipleVariants.findNearestFor(deviceDisplayWidth, lowQualityUrl);
+                  imageUrl = imageWithMultipleVariants
+                      .findNearestFor(deviceDisplayWidth, ImageWithMultipleVariants.DEFAULT_VIEWER_MIN_WIDTH, lowQualityUrl);
                 }
               }
 

--- a/app/src/main/java/me/saket/dank/ui/submission/SubmissionImageLoader.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/SubmissionImageLoader.java
@@ -117,9 +117,12 @@ public class SubmissionImageLoader {
     } else {
       // Images supplied by Reddit are static, so cannot optimize for GIFs.
       String defaultImageUrl = mediaLink.lowQualityUrl();
-      return mediaLink.isGif()
-          ? defaultImageUrl
-          : ImageWithMultipleVariants.Companion.of(redditPreviews).findNearestFor(deviceDisplaySize.getWidth(), defaultImageUrl);
+      return mediaLink.isGif() ? defaultImageUrl :
+          ImageWithMultipleVariants.Companion.of(redditPreviews).findNearestFor(
+              deviceDisplaySize.getWidth(),
+              ImageWithMultipleVariants.DEFAULT_VIEWER_MIN_WIDTH,
+              defaultImageUrl
+          );
     }
   }
 

--- a/app/src/main/java/me/saket/dank/ui/submission/adapter/ImageWithMultipleVariants.kt
+++ b/app/src/main/java/me/saket/dank/ui/submission/adapter/ImageWithMultipleVariants.kt
@@ -66,6 +66,8 @@ class ImageWithMultipleVariants private constructor(private val optionalRedditPr
 
   companion object {
 
+    const val DEFAULT_VIEWER_MIN_WIDTH = 1200
+
     fun of(redditSuppliedImages: SubmissionPreview?): ImageWithMultipleVariants {
       return ImageWithMultipleVariants(Optional.ofNullable(redditSuppliedImages))
     }

--- a/app/src/main/java/me/saket/dank/ui/submission/adapter/ImageWithMultipleVariants.kt
+++ b/app/src/main/java/me/saket/dank/ui/submission/adapter/ImageWithMultipleVariants.kt
@@ -15,12 +15,17 @@ class ImageWithMultipleVariants private constructor(private val optionalRedditPr
   /**
    * Find an image provided by Reddit that is the closest to <var>preferredWidth</var>.
    * Gives preference to higher-res thumbnails if multiple images have the same distance from the preferred width.
+   *
+   * @param minWidth Minimum preview width.
+   * Specify -1 to find any preview. minWidth is ignored if it larger than preferredWidth
    */
   @Suppress("DEPRECATION")
-  fun findNearestFor(preferredWidth: Int): String {
+  fun findNearestFor(preferredWidth: Int, minWidth: Int): String? {
     if (optionalRedditPreviews.isEmpty) {
-      throw NoSuchElementException("No reddit supplied images present")
+      return null
     }
+
+    val minWidthChecked = if (minWidth > preferredWidth) -1 else minWidth
 
     val redditPreviews = optionalRedditPreviews.get().images[0]
     var closestImage: SubmissionPreview.Variation = redditPreviews.source
@@ -36,20 +41,27 @@ class ImageWithMultipleVariants private constructor(private val optionalRedditPr
       }
     }
 
-    // Reddit sends HTML-escaped URLs.
-    return Html.fromHtml(closestImage.url).toString()
+    return if (closestImage.width < minWidthChecked) null else {
+      // Reddit sends HTML-escaped URLs.
+      Html.fromHtml(closestImage.url).toString()
+    }
   }
 
-  fun findNearestFor(preferredWidth: Int, defaultValue: String): String {
+  fun findNearestFor(preferredWidth: Int): String {
+    return this.findNearestFor(preferredWidth, -1) ?:
+      throw NoSuchElementException("No reddit supplied images present")
+  }
+
+  fun findNearestFor(preferredWidth: Int, minWidth: Int, defaultValue: String): String {
     if (UrlParser.isGifUrl(defaultValue)) {
       throw AssertionError("Optimizing GIFs is an error: $defaultValue")
     }
 
-    return if (optionalRedditPreviews.isPresent) {
-      findNearestFor(preferredWidth)
-    } else {
-      defaultValue
-    }
+    return this.findNearestFor(preferredWidth, minWidth) ?: defaultValue
+  }
+
+  fun findNearestFor(preferredWidth: Int, defaultValue: String): String {
+    return findNearestFor(preferredWidth, -1, defaultValue)
   }
 
   companion object {


### PR DESCRIPTION
Sometimes reddit provides only very small previews (around 150x300). With minWidth these can be ignored in normal (non-thumbnail) viewers so they will use lowQualityUrl instead

Example thread: https://old.reddit.com/r/pics/comments/g43i3y/whose_dream_was_it/
(reproducible with data saver enabled in settings)