### PR TITLE
Fix sharing of image multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Show smaller Imgur images when data saving mode enabled ([#256](https://github.com/Tunous/Dawn/pull/256))
 - Don't show too small reddit previews ([#264](https://github.com/Tunous/Dawn/pull/264))
+- Fix sharing an image multiple times ([#280](https://github.com/Tunous/Dawn/pull/280))
 
 ## [0.9.2] - 2020-06-13
 

--- a/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
+++ b/app/src/main/java/me/saket/dank/ui/media/MediaAlbumViewerActivity.java
@@ -549,7 +549,7 @@ public class MediaAlbumViewerActivity extends DankActivity implements MediaFragm
                 // fail to parse images if there's no file format, so we'll have to create a copy.
                 String imageNameWithExtension = Urls.parseFileNameWithExtension(activeMediaItem.mediaLink().highQualityUrl());
                 File imageFileWithExtension = new File(imageFile.getParent(), imageNameWithExtension);
-                Files2.INSTANCE.copy(imageFile, imageFileWithExtension);
+                if (!imageFileWithExtension.exists()) Files2.INSTANCE.copy(imageFile, imageFileWithExtension);
                 return imageFileWithExtension;
               })
               .compose(RxUtils.applySchedulersSingle())


### PR DESCRIPTION
To reproduce the bug:

1. Open any image
2. Select the 'Share image' option
3. Dismiss the share sheet that shows up
4. Select 'Share image' again
5. Observe that sharing fails this time
