### PR TITLE
Add another Redgifs domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Add support for alternate Redgifs domain ([#281](https://github.com/Tunous/Dawn/pull/281))
 
 ### Fixed
 

--- a/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
+++ b/app/src/main/java/me/saket/dank/urlparser/UrlParser.java
@@ -197,7 +197,7 @@ public class UrlParser {
     } else if (urlDomain.contains("gfycat.com")) {
       return createGfycatLink(linkURI);
 
-    } else if (urlDomain.contains("redgifs.com")) {
+    } else if (urlDomain.contains("redgifs.com") || urlDomain.contains("gifdeliverynetwork.com")) {
       return createRedgifsLink(linkURI);
 
     } else if (urlDomain.contains("giphy.com")) {


### PR DESCRIPTION
gifdeliverynetwork.com is also owned by Redgifs and works with
their API.
