### PR TITLE
Group download notifications + remove seekbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Show smaller Imgur images when data saving mode enabled ([#256](https://github.com/Tunous/Dawn/pull/256))
 - Don't show too small reddit previews ([#264](https://github.com/Tunous/Dawn/pull/264))
 - Fix sharing an image multiple times ([#280](https://github.com/Tunous/Dawn/pull/280))
+- Allow grouping of media download notifications ([#285](https://github.com/Tunous/Dawn/pull/285))
 
 ## [0.9.2] - 2020-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Don't show too small reddit previews ([#264](https://github.com/Tunous/Dawn/pull/264))
 - Fix sharing an image multiple times ([#280](https://github.com/Tunous/Dawn/pull/280))
 - Allow grouping of media download notifications ([#285](https://github.com/Tunous/Dawn/pull/285))
+- Workaround invisible download notifications on Android 11 ([#282](https://github.com/Tunous/Dawn/issues/282))
 
 ## [0.9.2] - 2020-06-13
 

--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -359,7 +359,7 @@ public class MediaDownloadService extends Service {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
       Notification summaryNotification = new NotificationCompat.Builder(MediaDownloadService.this, channel)
           .setSmallIcon(R.drawable.ic_done_24dp)
-          .setGroup(NotificationConstants.MEDIA_DOWNLOAD_GROUP)
+          .setGroup(NotificationConstants.MEDIA_DOWNLOAD_SUCCESS_GROUP)
           .setGroupSummary(true)
           .setShowWhen(true)
           .setDefaults(Notification.DEFAULT_ALL)
@@ -424,7 +424,7 @@ public class MediaDownloadService extends Service {
                 .setSmallIcon(R.drawable.ic_done_24dp)
                 .setOngoing(false)
                 .setLocalOnly(true)
-                .setGroup(NotificationConstants.MEDIA_DOWNLOAD_GROUP)
+                .setGroup(NotificationConstants.MEDIA_DOWNLOAD_SUCCESS_GROUP)
                 .setWhen(completedDownloadJob.timestamp())
                 .setContentIntent(viewImagePendingIntent)
                 .addAction(shareImageAction)

--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.media.MediaMetadata;
 import android.media.session.MediaSession;
 import android.net.Uri;
 import android.os.Build;
@@ -421,6 +422,8 @@ public class MediaDownloadService extends Service {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
               MediaSession poop = new MediaSession(getBaseContext(), "me.saket.Dank.dummyMediaSession");
               MediaSessionCompat.Token dummyTokenCompat = MediaSessionCompat.Token.fromToken(poop.getSessionToken());
+              MediaMetadata meta = new MediaMetadata.Builder().putLong(MediaMetadata.METADATA_KEY_DURATION, -1).build();
+              poop.setMetadata(meta);
               poop.release();
 
               notificationBuilder = notificationBuilder

--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -435,7 +435,9 @@ public class MediaDownloadService extends Service {
 
             // Taking advantage of O's tinted media notifications! I feel bad for this.
             // Let's see if anyone from Google asks me to remove this.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // ---
+            // Android 11 finally broke this so we'll force it to use BigPicture style for now
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Build.VERSION.SDK_INT < 30) {
               MediaSession poop = new MediaSession(getBaseContext(), "me.saket.Dank.dummyMediaSession");
               MediaSessionCompat.Token dummyTokenCompat = MediaSessionCompat.Token.fromToken(poop.getSessionToken());
               MediaMetadata meta = new MediaMetadata.Builder().putLong(MediaMetadata.METADATA_KEY_DURATION, -1).build();

--- a/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
+++ b/app/src/main/java/me/saket/dank/notifs/MediaDownloadService.java
@@ -354,6 +354,22 @@ public class MediaDownloadService extends Service {
     NotificationManagerCompat.from(this).notify(notificationId, errorNotification);
   }
 
+  private void displaySummaryNotification(NotificationManagerCompat nm, String channel) {
+    // No point in grouping download notifications on < Nougat since summary notification won't be exapndable
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      Notification summaryNotification = new NotificationCompat.Builder(MediaDownloadService.this, channel)
+          .setSmallIcon(R.drawable.ic_done_24dp)
+          .setGroup(NotificationConstants.MEDIA_DOWNLOAD_GROUP)
+          .setGroupSummary(true)
+          .setShowWhen(true)
+          .setDefaults(Notification.DEFAULT_ALL)
+          .setOnlyAlertOnce(true)
+          .setAutoCancel(true)
+          .build();
+      nm.notify(NotificationConstants.ID_MEDIA_DOWNLOAD_SUCCESS_BUNDLE_SUMMARY, summaryNotification);
+    }
+  }
+
   /**
    * Generate a notification with a preview of the media. Images and videos both work, thanks to Glide.
    */
@@ -446,7 +462,9 @@ public class MediaDownloadService extends Service {
             }
 
             Notification successNotification = notificationBuilder.build();
-            NotificationManagerCompat.from(MediaDownloadService.this).notify(notificationId, successNotification);
+            NotificationManagerCompat nm = NotificationManagerCompat.from(MediaDownloadService.this);
+            displaySummaryNotification(nm, notificationChannelId);
+            nm.notify(notificationId, successNotification);
           }
         });
   }

--- a/app/src/main/java/me/saket/dank/notifs/NotificationConstants.java
+++ b/app/src/main/java/me/saket/dank/notifs/NotificationConstants.java
@@ -5,6 +5,7 @@ package me.saket.dank.notifs;
  */
 public class NotificationConstants {
   public static final int ID_UNREAD_MESSAGES_BUNDLE_SUMMARY = 100;
+  public static final int ID_MEDIA_DOWNLOAD_SUCCESS_BUNDLE_SUMMARY = 101;
   public static final String UNREAD_MESSAGE_BUNDLE_NOTIFS_GROUP_KEY = "unreadMessagesBundle";
   public static final String UNREAD_MESSAGE_PREFIX_ = "unreadMessage_";
 

--- a/app/src/main/java/me/saket/dank/notifs/NotificationConstants.java
+++ b/app/src/main/java/me/saket/dank/notifs/NotificationConstants.java
@@ -11,4 +11,5 @@ public class NotificationConstants {
 
   public static final String ID_MEDIA_DOWNLOAD_PROGRESS_PREFIX_ = "mediaDownloadProgress_";
   public static final String MEDIA_DOWNLOAD_GROUP = "mediaDownloadNotifs";
+  public static final String MEDIA_DOWNLOAD_SUCCESS_GROUP = "mediaDownloadSuccessNotifs";
 }


### PR DESCRIPTION
![dawn_download_notif](https://user-images.githubusercontent.com/46577212/88468953-be1a7080-cef3-11ea-9e17-451d5ea3e38b.jpg)

Enable grouping of successful media download notifications.  
Also remove seekbar so that they look normal on Android >=9