### PR TITLE
Fix conversion of time to milliseconds

### DIFF
--- a/app/src/main/java/me/saket/dank/reply/ReplyRepository.java
+++ b/app/src/main/java/me/saket/dank/reply/ReplyRepository.java
@@ -221,7 +221,7 @@ public class ReplyRepository implements DraftStore {
   void recycleOldDrafts(Map<String, ReplyDraft> allDrafts) {
     LocalDateTime nowDateTime = LocalDateTime.now(UTC);
     LocalDateTime draftDateLimit = nowDateTime.minusDays(recycleDraftsOlderThanNumDays);
-    long draftDateLimitMillis = draftDateLimit.getNano() / 1000000;
+    long draftDateLimitMillis = draftDateLimit.toInstant(UTC).toEpochMilli();
 
     SharedPreferences.Editor sharedPrefsEditor = sharedPrefs.edit();
 

--- a/app/src/test/java/me/saket/dank/reply/ReplyRepositoryShould.java
+++ b/app/src/test/java/me/saket/dank/reply/ReplyRepositoryShould.java
@@ -93,7 +93,7 @@ public class ReplyRepositoryShould {
   public void onRecycleOldDrafts_shouldCorrectlyRecycleStaleDrafts() {
     Map<String, ReplyDraft> savedDrafts = new HashMap<>();
     ZonedDateTime twoWeeksOldDate = Instant.ofEpochMilli(System.currentTimeMillis()).atZone(UTC).minusDays(RECYCLE_DRAFTS_IN_DAYS + 1);
-    long twoWeeksOldTimeMillis = twoWeeksOldDate.getNano() / 1000000;
+    long twoWeeksOldTimeMillis = twoWeeksOldDate.toInstant().toEpochMilli();
     savedDrafts.put("oldKey", ReplyDraft.create("oldDraft", twoWeeksOldTimeMillis));
     savedDrafts.put("newKey", ReplyDraft.create("newDraft", System.currentTimeMillis()));
 


### PR DESCRIPTION
This fixes incorrect conversion of time from recent pull request which migrated to ThreTen backport.

The previously used `getNano` method returned nano-of-second field for the current time which is not the same as number of nanoseconds from epoch. A proper solution is to convert the time to an `Instant` and get the correct number of milliseconds since epoch from here.