### PR TITLE
Change repository order to prioritize jcenter above jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,8 @@ buildscript {
 allprojects {
   repositories {
     google()
-    maven { url 'https://jitpack.io' }
     jcenter()
+    maven { url 'https://jitpack.io' }
   }
 }
 


### PR DESCRIPTION
Closes #311

That should resolve the problem in linked issue. Any dependencies that are also available in jcenter will now be prioritized.

@AbsurdlySuspicious please review whether it works for you too after clearing cache.