### PR TITLE
Fix Gfycat extractor

### DIFF
--- a/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatResponse.java
@@ -25,10 +25,10 @@ public abstract class GfycatResponse {
     @Json(name = "gfyName")
     public abstract String threeWordId();
 
-    @Json(name = "webmUrl")
+    @Json(name = "mp4Url")
     public abstract String highQualityUrl();
 
-    @Json(name = "miniUrl")
+    @Json(name = "mobileUrl")
     public abstract String lowQualityUrl();
 
     public static JsonAdapter<Data> jsonAdapter(Moshi moshi) {


### PR DESCRIPTION
The GfyCat API no longer returns WebM videos and instead replaced them with MP4 for all qualities. The `mobileUrl` field contains a 480p video and the `mp4Url` field contains either 720p or 1080p depending on the source quality, which feels like a good approximation