### PR TITLE
Fix uses of auto-value-moshi

### DIFF
--- a/app/src/main/java/me/saket/dank/data/CachedResolvedLinkInfo.java
+++ b/app/src/main/java/me/saket/dank/data/CachedResolvedLinkInfo.java
@@ -4,6 +4,7 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.ui.media.MediaHostRepository;
@@ -16,6 +17,7 @@ import me.saket.dank.urlparser.StreamableLink;
 /**
  * Used by {@link MediaHostRepository} to figure out the wrapped class type for deserializing the actual resolved link.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class CachedResolvedLinkInfo {
 

--- a/app/src/main/java/me/saket/dank/data/UnfurlLinkResponse.java
+++ b/app/src/main/java/me/saket/dank/data/UnfurlLinkResponse.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.di.DankApi;
@@ -13,6 +14,7 @@ import me.saket.dank.urlparser.LinkMetadata;
 /**
  * Api response for {@link DankApi#unfurlUrl(String, boolean)}.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class UnfurlLinkResponse {
 

--- a/app/src/main/java/me/saket/dank/reply/ReplyDraft.java
+++ b/app/src/main/java/me/saket/dank/reply/ReplyDraft.java
@@ -2,8 +2,10 @@ package me.saket.dank.reply;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ReplyDraft {
 

--- a/app/src/main/java/me/saket/dank/ui/giphy/GiphySearchResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/giphy/GiphySearchResponse.java
@@ -3,6 +3,7 @@ package me.saket.dank.ui.giphy;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import java.util.List;
@@ -12,6 +13,7 @@ import me.saket.dank.di.DankApi;
 /**
  * API response for {@link DankApi#giphySearch(String, String, int, int)} and {@link DankApi#giphyTrending(String, int, int)}.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GiphySearchResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurAlbumResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurAlbumResponse.java
@@ -6,6 +6,7 @@ import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import java.util.List;
@@ -15,6 +16,7 @@ import me.saket.dank.di.DankApi;
 /**
  * API response body of {@link DankApi#imgurAlbum(String)}.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurAlbumResponse implements ImgurResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurImage.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurImage.java
@@ -8,8 +8,10 @@ import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurImage implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurImageResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurImageResponse.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import java.util.Collections;
@@ -14,6 +15,7 @@ import me.saket.dank.di.DankApi;
 /**
  * API response body of {@link DankApi#imgurImage(String)}.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurImageResponse implements ImgurResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/media/ImgurUploadResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/ImgurUploadResponse.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.di.DankApi;
@@ -13,6 +14,7 @@ import okhttp3.MultipartBody;
 /**
  * Response body for {@link DankApi#uploadToImgur(MultipartBody.Part, String)}.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurUploadResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatOauthResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatOauthResponse.java
@@ -3,8 +3,10 @@ package me.saket.dank.ui.media.gfycat;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GfycatOauthResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatResponse.java
+++ b/app/src/main/java/me/saket/dank/ui/media/gfycat/GfycatResponse.java
@@ -3,8 +3,10 @@ package me.saket.dank.ui.media.gfycat;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GfycatResponse {
 

--- a/app/src/main/java/me/saket/dank/ui/preferences/TypefaceResource.java
+++ b/app/src/main/java/me/saket/dank/ui/preferences/TypefaceResource.java
@@ -11,12 +11,14 @@ import androidx.annotation.RequiresApi;
 import com.f2prateek.rx.preferences2.Preference;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import java.io.IOException;
 
 import io.reactivex.exceptions.Exceptions;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class TypefaceResource {
 

--- a/app/src/main/java/me/saket/dank/ui/submission/AuditedCommentSort.java
+++ b/app/src/main/java/me/saket/dank/ui/submission/AuditedCommentSort.java
@@ -4,10 +4,12 @@ import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import net.dean.jraw.models.CommentSort;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class AuditedCommentSort implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/ui/user/UserSubreddit.java
+++ b/app/src/main/java/me/saket/dank/ui/user/UserSubreddit.java
@@ -3,12 +3,14 @@ package me.saket.dank.ui.user;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.Json;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 /**
  * Holds information about Reddit's new "profile pages", which are somewhat like user's
  * own subreddit with a banner image, profile image and a bio.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class UserSubreddit {
 

--- a/app/src/main/java/me/saket/dank/urlparser/GenericMediaLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/GenericMediaLink.java
@@ -4,6 +4,7 @@ import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.utils.Urls;
@@ -12,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Direct link to a media hosted by an unknown/unsupported-yet website.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GenericMediaLink extends MediaLink implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/urlparser/GfycatLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/GfycatLink.java
@@ -4,6 +4,7 @@ import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.BuildConfig;
@@ -14,6 +15,7 @@ import timber.log.Timber;
 /**
  * Gfycat.com for GIFs (converted to MP4).
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GfycatLink extends MediaLink implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/urlparser/GiphyLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/GiphyLink.java
@@ -4,6 +4,7 @@ import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.BuildConfig;
@@ -14,6 +15,7 @@ import timber.log.Timber;
 /**
  * Giphy.com for GIFs (converted to MP4s).
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class GiphyLink extends MediaLink implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/urlparser/ImgurAlbumLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/ImgurAlbumLink.java
@@ -6,11 +6,13 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurAlbumLink extends MediaAlbumLink<ImgurLink> implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/urlparser/ImgurLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/ImgurLink.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.BuildConfig;
@@ -13,6 +14,7 @@ import me.saket.dank.utils.Urls;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class ImgurLink extends MediaLink implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/urlparser/LinkMetadata.java
+++ b/app/src/main/java/me/saket/dank/urlparser/LinkMetadata.java
@@ -6,11 +6,13 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 /**
  * Meta-data of a URL.
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class LinkMetadata {
 

--- a/app/src/main/java/me/saket/dank/urlparser/StreamableLink.java
+++ b/app/src/main/java/me/saket/dank/urlparser/StreamableLink.java
@@ -4,6 +4,7 @@ import android.os.Parcelable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import me.saket.dank.BuildConfig;
@@ -11,6 +12,7 @@ import me.saket.dank.utils.Urls;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class StreamableLink extends MediaLink implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/utils/DankSubmissionRequest.java
+++ b/app/src/main/java/me/saket/dank/utils/DankSubmissionRequest.java
@@ -6,6 +6,7 @@ import androidx.annotation.Nullable;
 
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import net.dean.jraw.models.CommentSort;
@@ -18,6 +19,7 @@ import me.saket.dank.ui.submission.AuditedCommentSort;
  * <p>
  * TODO Use CommentsRequest#copy().
  */
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class DankSubmissionRequest implements Parcelable {
 

--- a/app/src/main/java/me/saket/dank/utils/TimeInterval.java
+++ b/app/src/main/java/me/saket/dank/utils/TimeInterval.java
@@ -5,6 +5,7 @@ import androidx.annotation.NonNull;
 import com.f2prateek.rx.preferences2.Preference;
 import com.google.auto.value.AutoValue;
 import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonClass;
 import com.squareup.moshi.Moshi;
 
 import java.io.IOException;
@@ -12,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import io.reactivex.exceptions.Exceptions;
 
+@JsonClass(generateAdapter = true, generator = "avm")
 @AutoValue
 public abstract class TimeInterval {
 


### PR DESCRIPTION
Relying on the static-method-only variant has a lot of caveats as noted in the [usage section](https://github.com/rharter/auto-value-moshi#usage) of `auto-value-moshi`, so this PR switches us to using the `@JsonClass` annotation and configuring auto from there. I also had logcat splats about `LinkMetadata` failing to (de)serialize due to a missing JsonAdapter class which this change fixes.