### PR TITLE
Improve commonmark dependency resolution logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ allprojects {
     // Our markwon dependency brings in outdated and conflicting commonmark versions, which we repair here.
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
       if (details.requested.group == "com.atlassian.commonmark") {
-        details.useVersion versions.commonmark
+        details.useTarget group: "org.commonmark", name: details.requested.name, version: versions.commonmark
         details.because "Markwon transitively includes outdated commonmark versions"
       }
     }


### PR DESCRIPTION
Had a lightbulb moment. This makes the dependency resolution happen in lesser steps and in a way that's more representative of our exact requirements. Atlassian will no longer publish new versions under `com.atlassian.commonmark` so being able to transparently force `org.commonmark` is a necessary future-proofing step.


```diff
 \--- project :markdownhints
      \--- com.github.saketme:markwon:b68d3058ca
           \--- com.github.saketme.markwon:library:b68d3058ca
-               +--- com.atlassian.commonmark:commonmark:0.10.0 -> 0.17.0
-               |    \--- org.commonmark:commonmark:0.17.0
-               +--- com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:0.10.0 -> 0.17.0
-               |    \--- org.commonmark:commonmark-ext-gfm-strikethrough:0.17.0
-               |         \--- org.commonmark:commonmark:0.17.0
-               \--- com.atlassian.commonmark:commonmark-ext-gfm-tables:0.10.0 -> 0.17.0
-                    \--- org.commonmark:commonmark-ext-gfm-tables:0.17.0
-                         \--- org.commonmark:commonmark:0.17.0
+               +--- com.atlassian.commonmark:commonmark:0.10.0 -> org.commonmark:commonmark:0.17.0
+               +--- com.atlassian.commonmark:commonmark-ext-gfm-strikethrough:0.10.0 -> org.commonmark:commonmark-ext-gfm-strikethrough:0.17.0
+               |    \--- org.commonmark:commonmark:0.17.0
+               \--- com.atlassian.commonmark:commonmark-ext-gfm-tables:0.10.0 -> org.commonmark:commonmark-ext-gfm-tables:0.17.0
+                    \--- org.commonmark:commonmark:0.17.0

```