### PR TITLE
Raise target API to 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.wrapper.Wrapper.DistributionType
 buildscript {
   ext.versions = [
       minSdk          : 23,
-      compileSdk      : 28,
+      compileSdk      : 30,
       supportLib      : '28.0.0',
       glide           : '4.11.0',
       autoValue       : '1.5',


### PR DESCRIPTION
We don't use anything that could run afoul of the platform changes in Android 10 and 11. The app continues to work for me on my Pixel 4a running Android 11, and we can all give this a try for a day or two to confirm that things are indeed fine.

Fixes #389