### PR TITLE
dependabot: ignore commonmark upgrades for now

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,3 +6,5 @@ update_configs:
     ignored_updates:
       - match:
           dependency_name: "com.alexvasilkov:gesture-views"
+      - match:
+          dependency_name: "com.atlassian.commonmark:commonmark-ext-autolink"


### PR DESCRIPTION
It breaks markdown parsing and we'll be updating it separately once Markwon is on v4